### PR TITLE
Control display global events

### DIFF
--- a/UI/controls_display/controls_display.gd
+++ b/UI/controls_display/controls_display.gd
@@ -1,6 +1,38 @@
 extends Control
 
 @onready var tabs : TabContainer = %TabContainer
+@onready var instruction_text : RichTextLabel = %InstructionText
+var key_options
+var gadget_options
 
 func _ready() -> void:
+	
+	gadget_options = tabs.get_child(0)
+	key_options = tabs.get_child(1)
+
+	GlobalEvents.story_bot_index_changed.connect(
+		func(value):
+			if value == 4:
+				instruction_text.text = str(instruction_text.text, "Press Q to switch to keys. Click on the key gizmo and spin it. Use keys to charge nearby objects. ")
+			if value == 7:
+				instruction_text.text = str(instruction_text.text, "Press and hold space to interact with gadgets. Use WASD to maneuver the jetpack.")
+			if value == 8:
+				gadget_options.get_node("Label").visible = true
+				gadget_options.get_node("Label3").visible = true
+	)
+	GlobalEvents.gadget_obtained.connect(
+		func(value):
+			if value.name == "EmpObject":
+				gadget_options.get_node("Label2").visible = true
+			instruction_text.text = ""
+			instruction_text.text = str(instruction_text.text, "Press Q to switch to gadgets and 2 to deploy the emp. Charge and throw the emp object.")
+
+	)
+	GlobalEvents.key_obtained.connect(
+		func():
+			if Globals.obtained_keys.has(2):
+				key_options.get_node("Label2").visible = true
+			instruction_text.text = str(instruction_text.text, "Press Q and 2 to switch the light key. Charge nearby objects with the light key. After spinning the light key will remotely trigger objects")
+	)
+
 	GlobalEvents.control_option_switch.connect(func(value): tabs.current_tab = max(0, value))

--- a/UI/controls_display/controls_display.tscn
+++ b/UI/controls_display/controls_display.tscn
@@ -14,18 +14,24 @@ script = ExtResource("1_jah1c")
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 1
-anchors_preset = 2
+anchors_preset = 3
+anchor_left = 1.0
 anchor_top = 1.0
+anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 0
 grow_vertical = 0
 
 [node name="MarginContainer" type="MarginContainer" parent="Control"]
 layout_mode = 1
-anchors_preset = 2
+anchors_preset = 3
+anchor_left = 1.0
 anchor_top = 1.0
+anchor_right = 1.0
 anchor_bottom = 1.0
-offset_top = -210.0
-offset_right = 305.0
+offset_left = -369.0
+offset_top = -182.0
+grow_horizontal = 0
 grow_vertical = 0
 theme_override_constants/margin_left = 32
 theme_override_constants/margin_top = 32
@@ -40,15 +46,17 @@ unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 2
 tab_alignment = 1
-current_tab = 0
+current_tab = 1
 clip_tabs = false
 
 [node name="GadgetOptions (Q)" type="GridContainer" parent="Control/MarginContainer/VBoxContainer/TabContainer"]
+visible = false
 layout_mode = 2
 columns = 3
 metadata/_tab_index = 0
 
 [node name="Label" type="Label" parent="Control/MarginContainer/VBoxContainer/TabContainer/GadgetOptions (Q)"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Deploy
@@ -57,6 +65,7 @@ Jetpack
 horizontal_alignment = 1
 
 [node name="Label2" type="Label" parent="Control/MarginContainer/VBoxContainer/TabContainer/GadgetOptions (Q)"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Deploy
@@ -65,6 +74,7 @@ EMP
 horizontal_alignment = 1
 
 [node name="Label3" type="Label" parent="Control/MarginContainer/VBoxContainer/TabContainer/GadgetOptions (Q)"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Pick up
@@ -73,7 +83,6 @@ Gadget
 horizontal_alignment = 1
 
 [node name="KeyOptions (Q)" type="GridContainer" parent="Control/MarginContainer/VBoxContainer/TabContainer"]
-visible = false
 layout_mode = 2
 columns = 3
 metadata/_tab_index = 1
@@ -87,6 +96,7 @@ Key
 horizontal_alignment = 1
 
 [node name="Label2" type="Label" parent="Control/MarginContainer/VBoxContainer/TabContainer/KeyOptions (Q)"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Light
@@ -95,6 +105,7 @@ Key
 horizontal_alignment = 1
 
 [node name="Label3" type="Label" parent="Control/MarginContainer/VBoxContainer/TabContainer/KeyOptions (Q)"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Remote
@@ -112,12 +123,9 @@ theme_override_constants/margin_top = 4
 theme_override_constants/margin_right = 4
 theme_override_constants/margin_bottom = 4
 
-[node name="RichTextLabel" type="RichTextLabel" parent="Control/MarginContainer/VBoxContainer/PanelContainer/MarginContainer"]
+[node name="InstructionText" type="RichTextLabel" parent="Control/MarginContainer/VBoxContainer/PanelContainer/MarginContainer"]
+unique_name_in_owner = true
 layout_mode = 2
-text = "Press space to interact with gadgets.
-WASD to control the jetpack.
-Use the mouse to throw the EMP.
-Keys can be used once near a gadget."
 fit_content = true
 
 [node name="Panel" type="Panel" parent="Control/MarginContainer"]

--- a/global_autoload/global_events.gd
+++ b/global_autoload/global_events.gd
@@ -11,6 +11,9 @@ signal story_bot_skip_to_index
 signal player_death
 signal set_checkpoint
 
+signal key_obtained
+signal gadget_obtained
+
 signal control_option_switch
 var control_option : int = -1
 

--- a/global_autoload/globals.gd
+++ b/global_autoload/globals.gd
@@ -8,5 +8,4 @@ var start_point: Vector2
 var checkpoint: Vector2
 
 var obtained_gadgets = []
-
 var obtained_keys = []

--- a/scenes/level00/checkpoint_area/emp_room_checkpoint.gd
+++ b/scenes/level00/checkpoint_area/emp_room_checkpoint.gd
@@ -1,0 +1,9 @@
+extends Area2D
+
+@export var emp_node : Node2D
+
+func _ready() -> void:
+    body_entered.connect(
+        func(_value):
+            GlobalEvents.gadget_obtained.emit(emp_node),
+    )

--- a/scenes/level00/checkpoint_area/emp_room_checkpoint.gd.uid
+++ b/scenes/level00/checkpoint_area/emp_room_checkpoint.gd.uid
@@ -1,0 +1,1 @@
+uid://bkdemv4m1pfwy

--- a/scenes/level00/items/light_key_item.gd
+++ b/scenes/level00/items/light_key_item.gd
@@ -3,4 +3,4 @@ extends Node2D
 @onready var area :Area2D = get_node("Area2D")
 
 func _ready() -> void:
-    area.body_entered.connect(func(_value): Globals.obtained_keys.append(2); print("light key obtained"); queue_free(),)
+    area.body_entered.connect(func(_value): Globals.obtained_keys.append(2); GlobalEvents.key_obtained.emit(); queue_free(),)

--- a/scenes/level00/level00.tscn
+++ b/scenes/level00/level00.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=74 format=4 uid="uid://bbpxit1isuy13"]
+[gd_scene load_steps=77 format=4 uid="uid://bbpxit1isuy13"]
 
 [ext_resource type="TileSet" uid="uid://c8nrnjf8fsfw0" path="res://map/resources/default_tileset.tres" id="1_m831i"]
 [ext_resource type="Script" uid="uid://di362p0l14ryw" path="res://scenes/level00/doors/triple_door/moving_platform_shield.gd" id="1_q30id"]
@@ -25,6 +25,7 @@
 [ext_resource type="PackedScene" uid="uid://dduacje26mt8b" path="res://manager_systems/screen_effect_manager/screen_effects_manager.tscn" id="15_si1ye"]
 [ext_resource type="Texture2D" uid="uid://hqmafcal53s3" path="res://scenes/level00/los_turret/turret_gun.png" id="16_ak84c"]
 [ext_resource type="Script" uid="uid://po87hcrrbmbv" path="res://scenes/level00/los_turret/los_turret.gd" id="16_la4if"]
+[ext_resource type="Script" uid="uid://bkdemv4m1pfwy" path="res://scenes/level00/checkpoint_area/emp_room_checkpoint.gd" id="17_4fpck"]
 [ext_resource type="AudioStream" uid="uid://b25n8207emop8" path="res://scenes/level00/los_turret/continuous laser start.ogg" id="17_rrkdo"]
 [ext_resource type="AudioStream" uid="uid://dmpxf67uxswd7" path="res://scenes/level00/los_turret/Continuous Laser loop.ogg" id="18_pg7fu"]
 [ext_resource type="AudioStream" uid="uid://cdkfo8jokggxe" path="res://scenes/level00/los_turret/Continuous laser end.ogg" id="19_3s6ok"]
@@ -39,6 +40,7 @@
 [ext_resource type="PackedScene" uid="uid://bjp4e0btlhpsa" path="res://scenes/level00/items/light_key_item.tscn" id="34_1v3bv"]
 [ext_resource type="PackedScene" uid="uid://dga7y3vw74cmx" path="res://scenes/enemy/clockwork/clockwork_enemy.tscn" id="35_s2o0g"]
 [ext_resource type="PackedScene" uid="uid://ccvaya45j8x0y" path="res://scenes/enemy/men_in_black/men_in_black.tscn" id="36_0sf4y"]
+[ext_resource type="PackedScene" uid="uid://dejnlebot27dd" path="res://UI/controls_display/controls_display.tscn" id="37_bj6hi"]
 
 [sub_resource type="Curve2D" id="Curve2D_an840"]
 _data = {
@@ -968,6 +970,9 @@ size = Vector2(448, 304)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_vn2ov"]
 size = Vector2(85.3333, 138.667)
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_b0732"]
+size = Vector2(160, 192)
+
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ak84c"]
 size = Vector2(352, 48)
 
@@ -1534,7 +1539,17 @@ shape = SubResource("RectangleShape2D_vn2ov")
 
 [node name="KeyArea5" parent="Map" instance=ExtResource("4_kj78h")]
 position = Vector2(-1216, -832)
-skip_to_index = -1
+skip_to_index = 13
+
+[node name="EmpArea" type="Area2D" parent="Map" node_paths=PackedStringArray("emp_node")]
+position = Vector2(-848, -1344)
+collision_layer = 0
+collision_mask = 8
+script = ExtResource("17_4fpck")
+emp_node = NodePath("../../EmpObject")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Map/EmpArea"]
+shape = SubResource("RectangleShape2D_b0732")
 
 [node name="Hazard1" type="Polygon2D" parent="Map"]
 position = Vector2(-1520, -720)
@@ -1662,7 +1677,7 @@ texture = ExtResource("14_b7lq2")
 offset = Vector2(0, 2)
 
 [node name="VisualTreeRoot" type="AnimatedSprite2D" parent="Map/LOSTurret2"]
-position = Vector2(-7.99997, 40)
+position = Vector2(-7.99915, 40)
 scale = Vector2(2, 2)
 sprite_frames = SubResource("SpriteFrames_d3l2q")
 centered = false
@@ -1730,7 +1745,6 @@ position = Vector2(-112, -128)
 [node name="GameManager" parent="ManagerSystems" instance=ExtResource("13_la4if")]
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
-visible = false
 
 [node name="UI" type="Control" parent="CanvasLayer"]
 layout_mode = 3
@@ -1747,7 +1761,7 @@ offset_right = 40.0
 offset_bottom = 40.0
 scale = Vector2(1.5, 1.5)
 script = ExtResource("8_g03lo")
-stop_indices = PackedInt32Array(4, 7, 8, 9, 10, 11, 12, 13)
+stop_indices = PackedInt32Array(4, 7, 8, 9, 10, 11, 12, 13, 15)
 
 [node name="TextureRect" type="TextureRect" parent="CanvasLayer/UI/TutorialBot"]
 layout_mode = 2
@@ -1765,7 +1779,6 @@ theme_override_constants/margin_right = 4
 theme_override_constants/margin_bottom = 4
 
 [node name="Label0" type="Label" parent="CanvasLayer/UI/TutorialBot/PanelContainer/TextLines"]
-visible = false
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
 text = "Hello and welcome to our facility
@@ -1839,7 +1852,6 @@ horizontal_alignment = 1
 autowrap_mode = 3
 
 [node name="Label8" type="Label" parent="CanvasLayer/UI/TutorialBot/PanelContainer/TextLines"]
-visible = false
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
 text = "Press \"E\" to pickup any gadget in front of you. You will need it for the remainder of our study. Continue to the next room."
@@ -1875,6 +1887,7 @@ horizontal_alignment = 1
 autowrap_mode = 3
 
 [node name="Label12" type="Label" parent="CanvasLayer/UI/TutorialBot/PanelContainer/TextLines"]
+visible = false
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
 text = "In this next room, we will be assessing the range of your key device. On the right wall there are three locks. Charge them."
@@ -1883,11 +1896,32 @@ horizontal_alignment = 1
 autowrap_mode = 3
 
 [node name="Label13" type="Label" parent="CanvasLayer/UI/TutorialBot/PanelContainer/TextLines"]
+visible = false
+custom_minimum_size = Vector2(32, 32)
+layout_mode = 2
+text = "We will be providing a second key for you for this next assessment. Press \"Q\" and \"2\" to access and use your light key. [R>]"
+label_settings = SubResource("LabelSettings_g03lo")
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[node name="Label14" type="Label" parent="CanvasLayer/UI/TutorialBot/PanelContainer/TextLines"]
+visible = false
+custom_minimum_size = Vector2(32, 32)
+layout_mode = 2
+text = "Spin the key while near chargeable objects. [R>]"
+label_settings = SubResource("LabelSettings_g03lo")
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[node name="Label15" type="Label" parent="CanvasLayer/UI/TutorialBot/PanelContainer/TextLines"]
 custom_minimum_size = Vector2(32, 32)
 layout_mode = 2
 label_settings = SubResource("LabelSettings_g03lo")
 horizontal_alignment = 1
 autowrap_mode = 3
+
+[node name="ControlsDisplay" parent="CanvasLayer/UI" instance=ExtResource("37_bj6hi")]
+layout_mode = 1
 
 [node name="ScreenEffectsManager" parent="CanvasLayer" instance=ExtResource("15_si1ye")]
 

--- a/scenes/level00/level00.tscn
+++ b/scenes/level00/level00.tscn
@@ -1264,6 +1264,7 @@ material = ExtResource("6_1pv21")
 texture = ExtResource("7_kj78h")
 region_enabled = true
 region_rect = Rect2(40, 24, 46, 88)
+script = ExtResource("8_1v3bv")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Map/Door6/PathFollow2D/AnimatableBody2D"]
 shape = SubResource("RectangleShape2D_a55ot")


### PR DESCRIPTION
IMPORTANT: DO NOT USE JETPACK VERSION 1. Find jetpack_version2 and use that.
Control display now updates. Advised to keep this UI ON so that the player doesn't get confused.
Fixed electronic door. Needs gadget door sprite control to respond to shockwave effect.